### PR TITLE
Updated details

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ We've got you covered! Now with [Faucy](https://faucy.dev/) you can easily get e
 - ☁️ Reliable, with a redundancy faucet per testnet
 - 📊 GDPR complaint analytics (using [GoatCounter](https://www.gatsbyjs.org/packages/gatsby-plugin-matomo/))
 - 📦 Distributed over fast, performant and secure IPFS (using [Fleek](https://fleek.co))
+- 🔗 Available with ENS domain at [faucy.eth](https://faucy.eth.link)
 
 ## Supported Networks
 

--- a/frontend/statickit.json
+++ b/frontend/statickit.json
@@ -7,7 +7,7 @@
         "emotion": { "type": "text", "required": false },
         "feedback": { "type": "text", "required": true }
       },
-      "actions": [{ "type": "email", "to": "faucybot@gmail.com" }]
+      "actions": [{ "type": "email", "to": "faucy@xivis.com" }]
     }
   }
 }


### PR DESCRIPTION
### Updated goodies info and contact details

I created a new Xivis contact email to avoid using gmail and having more accounts.

Also updated the Goodies section with the ENS domain & link. Fleek is configured to update the IPFS hash on each deploy.
If the user has metamask installed or is using a web3 browser, the link https://faucy.eth works.
If not, all webs with ENS support are available by adding `.link` at the end: https://faucy.eth.link
To avoid a broken link in the `README.md`, I used the `.link` option 😊

**IMPORTANT NOTE: The statickit form has to be deployed again**
